### PR TITLE
Check permissions using uid instead of id

### DIFF
--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -87,7 +87,7 @@ class DefaultController extends Controller
         }
 
         // viewvolume permissions are required to access the volume
-        $volumePermission = 'viewvolume:' . $volume['id'];
+        $volumePermission = 'viewvolume:' . $volume['uid'];
 
         // get the current user session
         $currentUser = Craft::$app->getUser();


### PR DESCRIPTION
Craft 3 (using v3.1.15) looks for permissions based on volume uid

e.g. viewvolume:1ffaf8d4-f71e-4547-b28d-6b65450fb7c5