### PR TITLE
Added checks for old versions, isAdmin check and getAlias

### DIFF
--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -87,19 +87,17 @@ class DefaultController extends Controller
         }
 
         // viewvolume permissions are required to access the volume
-        // note: check for volume permission was changed from id to uid
-        // thanks to @jackgringo for the fix.
-        $volumePermission = 'viewvolume:' . $volume['uid'];
+        $volumePermission = 'viewvolume:' . $volume['id'];
 
         // get the current user session
         $currentUser = Craft::$app->getUser();
 
         // check if the user is allowed to access the volume
-        $accessGranted = $currentUser->checkPermission($volumePermission);
+        $accessGranted = $currentUser->checkPermission($volumePermission) || $currentUser->getIsAdmin();
 
-        // fallback to check permission with volume id instead of uid
-        if ($accessGranted === false) {
-            $volumePermission = 'viewvolume:' . $volume['id'];
+        // fallback to check permission with volume uid instead of id
+        if ($accessGranted === false && isset($volume['uid'])) {
+            $volumePermission = 'viewvolume:' . $volume['uid'];
             $accessGranted = $currentUser->checkPermission($volumePermission);
         }
 
@@ -111,7 +109,7 @@ class DefaultController extends Controller
 
         // generate the filesystem path to the file
         $filepath = ltrim($path, $volumeUrl);
-        $filepath = $volume['path'] . $filepath;
+        $filepath = Craft::getAlias($volume['path']) . $filepath;
         $filepath = FileHelper::normalizePath($filepath);
 
         // get only the filename

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -86,18 +86,26 @@ class DefaultController extends Controller
             return;
         }
 
-        // viewvolume permissions are required to access the volume
-        $volumePermission = 'viewvolume:' . $volume['id'];
-
         // get the current user session
         $currentUser = Craft::$app->getUser();
 
-        // check if the user is allowed to access the volume
-        $accessGranted = $currentUser->checkPermission($volumePermission) || $currentUser->getIsAdmin();
+        $accessGranted = $currentUser->getIsAdmin();
 
-        // fallback to check permission with volume uid instead of id
         if ($accessGranted === false && isset($volume['uid'])) {
+
+            // viewvolume permissions are required to access the volume
+            // note: check for volume permission was changed from id to uid
+            // thanks to @jackgringo for the fix.
             $volumePermission = 'viewvolume:' . $volume['uid'];
+
+            // check if the user is allowed to access the volume
+            $accessGranted = $currentUser->checkPermission($volumePermission);
+        }
+
+
+        // fallback to check permission with volume id instead of uid
+        if ($accessGranted === false && isset($volume['id'])) {
+            $volumePermission = 'viewvolume:' . $volume['id'];
             $accessGranted = $currentUser->checkPermission($volumePermission);
         }
 


### PR DESCRIPTION
I changed the following things to support older versions, allow access for admins and support aliases in configuration.

Changes:
- Added isset() for `volume[uid]` and `volume[id]`, otherwise the extension won't work with older versions (for example: craft cms 3.0.41.1)
- Added isAdmin check to allow access for admins even if they don't have view permissions for the volume
- Added `Craft::getAlias` to support Aliases in configuration (for example @webroot)