### PR TITLE
stop content-type from being overridden by Craft, fix null being appended to files

### DIFF
--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -58,6 +58,10 @@ class DefaultController extends Controller
     public function actionFetch(string $path)
     {
 
+        // stop content-type from being overridden
+        // https://github.com/craftcms/cms/issues/4716
+        Craft::$app->response->format = \yii\web\Response::FORMAT_RAW;
+
         // find the volume by the given path
         $volumes = Craft::$app->getVolumes();
         $publicVolumes = $volumes->getPublicVolumes();
@@ -129,7 +133,8 @@ class DefaultController extends Controller
             header('Accept-Ranges: bytes');
         }
         else {
-            header('Content-type: '. $mimeType);
+            header('Content-type: '.' $mimeType');
+            header('Content-Length: ' . filesize($filepath));
         }
 
         // NOTE: we could also use file_get_contents($filepath)


### PR DESCRIPTION
Hi Ramon,

I dug into the codebase and found a fix for the null being appended to the content. Needed to add the content-length to general header section (non-pdfs).

I also discovered that mime-types were not being set properly.  Per [this solution](https://github.com/craftcms/cms/issues/4716), I added line 63 setting the response format to raw.  You may even be able to remove the PDF specific section now with this in place but I didn't want to mess with it.

Things seems to be solid on my end now.

Thanks again!